### PR TITLE
KeyError when publishing to XRAY Cloud

### DIFF
--- a/src/behave_xray/xray_publisher.py
+++ b/src/behave_xray/xray_publisher.py
@@ -59,6 +59,10 @@ class XrayPublisher:
             _logger.error(e.message)
             return False
         else:
-            key = result['testExecIssue']['key']
+            _logger.debug('Publish returned: %s', result)
+            # XRAY Server+DC returns test execution information nested under 'testExecIssue'
+            # XRAY Cloud returns it directly
+            # Refer to XRAY API documentation for more details.
+            key = result['testExecIssue']['key'] if 'testExecIssue' in result else result['key']
             print('Uploaded results to JIRA XRAY Test Execution:', key)
             return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def http_server():
     # cloud jira:
     server.add_json_response(
         '/api/v2/import/execution',
-        {'testExecIssue': {'key': 'JIRA-1000'}},
+        {'key': 'JIRA-1000'},
         methods=('POST',)
     )
     server.add_callback_response(


### PR DESCRIPTION
When trying to publish the report to XRAY Cloud, the following exception is thrown:
```
Exception KeyError: 'testExecIssue'
Traceback (most recent call last):
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/bin/behave", line 33, in <module>
    sys.exit(load_entry_point('behave==1.2.6', 'console_scripts', 'behave')())
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave/__main__.py", line 183, in main
    return run_behave(config)
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave/__main__.py", line 127, in run_behave
    failed = runner.run()
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave/runner.py", line 804, in run
    return self.run_with_paths()
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave/runner.py", line 824, in run_with_paths
    return self.run_model()
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave/runner.py", line 626, in run_model
    failed = feature.run(self)
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave/model.py", line 350, in run
    formatter.eof()
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave_xray-0.0.0-py3.7.egg/behave_xray/formatter.py", line 133, in eof
    if c == '1':
  File "/Users/kristijan.conkas/.pyenv/versions/3.7.13/lib/python3.7/site-packages/behave_xray-0.0.0-py3.7.egg/behave_xray/xray_publisher.py", line 63, in publish
KeyError: 'testExecIssue'
```
I've traced the root issue to API differences between XRAY Cloud and XRAY Server+DC, in particular to what POST import execution returns. On [XRAY Server + DC](https://docs.getxray.app/display/XRAY/v2.0#/Import/post-import-execution) test execution is nested under `testExecIssue` whereas on [XRAY Cloud](https://docs.getxray.app/display/XRAYCLOUD/Import+Execution+Results+-+REST+v2#ImportExecutionResultsRESTv2-XrayJSONresults) it is not. This PR addresses this difference.