### PR TITLE
Fix of default test executions summary for non-first feature

### DIFF
--- a/src/behave_xray/formatter.py
+++ b/src/behave_xray/formatter.py
@@ -140,7 +140,12 @@ class _XrayFormatterBase(Formatter):
         self.current_feature = None
         self.current_scenario = None
         self.current_test_key = None
-        self.test_execution = TestExecution()
+        self.test_execution = TestExecution(
+            summary=self._get_summary(),
+            user=self._get_user(),
+            revision=self._get_revision(),
+            version=self._get_version()
+        )
         self.testcases = defaultdict(lambda: ScenarioResult())
 
     def feature(self, feature):


### PR DESCRIPTION
Right now behavior is pretty strange, when we execute several feature files with:

`behave -i tests/features --f xray -D xray.summary='Our cool summary'`

At the end we get only 1 xray ticket with `Our cool summary` summary and others have default one `Execution of automated tests`.
This PR suppose to deal this issue.