### PR TITLE
Merge multiple features in one XRAY result

### DIFF
--- a/tests/features/calculator2.feature
+++ b/tests/features/calculator2.feature
@@ -1,0 +1,13 @@
+@jira.test_plan('JIRA-1')
+Feature: Calculator2
+  Test if adding two numbers returns proper result.
+
+  @allure.testcase('JIRA-41')
+  Scenario: Add two numbers should pass
+    When I add 4 and 5
+    Then result is 9
+
+  @jira.testcase('JIRA-42')
+  Scenario: Add two numbers should failed
+    When I add 4 and 6
+    Then result is 9

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -25,7 +25,7 @@ def test_if_xray_formatter_publishes_results(formatter, auth_type, auth):
     )
     assert not process.stderr
     assert 'Uploaded results to JIRA XRAY Test Execution: JIRA-1000' in process.stdout, process.stdout
-    assert '4 scenarios passed, 2 failed, 0 skipped' in process.stdout, process.stdout
+    assert '5 scenarios passed, 3 failed, 0 skipped' in process.stdout, process.stdout
 
 
 def test_if_xray_formatter_results_matches_expected_format(auth, tmp_path):
@@ -42,13 +42,14 @@ def test_if_xray_formatter_results_matches_expected_format(auth, tmp_path):
     print(process.stdout)
     assert not process.stderr
     assert 'Uploaded results to JIRA XRAY Test Execution: JIRA-1000' in process.stdout
-    assert '4 scenarios passed, 2 failed, 0 skipped' in process.stdout
+    assert '5 scenarios passed, 3 failed, 0 skipped' in process.stdout
 
     with open(report_path.name, 'r') as f:
         report = json.load(f)
 
-    assert 'tests' in report
-    assert report['tests'] == [
+    assert len(report) == 1
+    assert 'tests' in report[0]
+    assert report[0]['tests'] == [
             {
                 'testKey': 'JIRA-31',
                 'status': 'PASS',
@@ -72,5 +73,17 @@ def test_if_xray_formatter_results_matches_expected_format(auth, tmp_path):
                 'status': 'FAIL',
                 'comment': '',  # FIXME: missing assertion message
                 'examples': ['PASS', 'FAIL']
+            },
+            {
+                'testKey': 'JIRA-41',
+                'status': 'PASS',
+                'comment': '',
+                'examples': []
+            },
+            {
+                'testKey': 'JIRA-42',
+                'status': 'FAIL',
+                'comment': 'Assertion Failed: Not equal',
+                'examples': []
             }
         ]


### PR DESCRIPTION
If there is multiple features files with the
same test plany ID and test execution ID
we should merge them in one XRAY results and publish only once #27.